### PR TITLE
Feature/define custom routes

### DIFF
--- a/Faux.js
+++ b/Faux.js
@@ -1,8 +1,9 @@
 const Config = require('./config');
-const { Start, Register } = require('./main');
+const { Start, Register, App } = require('./main');
 
 module.exports = {
   Start,
   Config,
   Register,
+  App,
 };

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
-const { Config, Start, Register } = require('./Faux');
+const { Config, Start, Register, App } = require('./Faux');
 
 /** Base faux wrapper */
 const faux = {
   config: Config,
   register: Register,
   start: Start,
+  route: App,
 }
 
 module.exports = faux;

--- a/main/index.js
+++ b/main/index.js
@@ -1,4 +1,5 @@
 const Start = require('./Start');
 const Register = require('./Register');
+const App = require('../server');
 
-module.exports = { Start, Register };
+module.exports = { App, Start, Register };

--- a/test.js
+++ b/test.js
@@ -60,5 +60,9 @@ faux.config.set('auth.namespace', '/auth');
 faux.register(UserModel);
 faux.register(ProfileModel);
 
+faux.route.get('/test', (req, res) => {
+  res.send('test');
+});
+
 // Start faux
 faux.start(3000);


### PR DESCRIPTION
# Description

Allow users to define custom routes and responses.

## Solution

Faux-call object now exposes the Express.js server through the `faux.route`.

## Proposed API

```js
const faux = require('faux-call');

faux.route.get('/custom/route/path', (req, res) => {
  return res.send('SEND CUSTOM RESPONSE');
});
```

## Release

- **Version 0.2.0**

## Issue

Resolves #9 