### PR TITLE
[FEATURE] Api prefix

### DIFF
--- a/config/base.config.js
+++ b/config/base.config.js
@@ -1,4 +1,6 @@
 module.exports = {
+  'api.prefix': '/',
+
   'auth.namespace': '/',
   'token.header': 'Authorization',
 

--- a/main/Register.js
+++ b/main/Register.js
@@ -3,6 +3,7 @@ const Model = require('../model/Model');
 
 const Register = ModelSchema => {
   const model = new Model(ModelSchema);
+  console.log('MODEL', model.route);
   Config.assign('models', model.name, model);
   if (ModelSchema.seed && ModelSchema.seed > 0) {
     Config.assign('seed', model.name, ModelSchema.seed);

--- a/model/Model.js
+++ b/model/Model.js
@@ -28,13 +28,28 @@ class Model {
 
   hydrate(ModelSchema) {
     this.name = Validate.name(ModelSchema.name);
-    this.route = Validate.route(ModelSchema.route);
+    this.route = this.generateRoute(Validate.route(ModelSchema.route));
     this.columns = Validate.columns(ModelSchema.columns);
     Object.keys(ModelSchema).forEach(property => {
-      if (check.isSet(Validate[property])) {
+      if (
+        !['name', 'route', 'columns'].includes(property) &&
+        check.isSet(Validate[property])
+      ) {
         this[property] = Validate[property](ModelSchema[property]);
       }
     });
+  }
+
+  generateRoute(route) {
+    const prefix = Config.get('api.prefix')
+      .replace(/  +/g, '-')
+      .replace(/^\/|\/$/g, '')
+      .toLowerCase();
+    const uri = route
+      .replace(/  +/g, '-')
+      .replace(/^\/|\/$/g, '')
+      .toLowerCase();
+    return `/${prefix}/${uri}`.replace(/\/\//g, '/');
   }
 
   validate(data) {
@@ -60,16 +75,24 @@ class Model {
     const eagerLoad = check.isObject(relationship)
       ? relationship
       : {
-          model: relationship,
+          model: relationship
         };
     let relationshipModel;
     if (this.hasOne[relationship.model]) {
       relationshipModel = Config.get('models')[relationship.model];
-      return relationshipModel.database.where(this.hasOne[relationship.model], model_id);
+      return relationshipModel.database.where(
+        this.hasOne[relationship.model],
+        model_id
+      );
     }
     if (this.hasMany[relationship.model]) {
       relationshipModel = Config.get('models')[relationship.model];
-      return relationshipModel.database.whereAll(this.hasMany[relationship.model], model_id) || [];
+      return (
+        relationshipModel.database.whereAll(
+          this.hasMany[relationship.model],
+          model_id
+        ) || []
+      );
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -55,6 +55,7 @@ const faux = require('./index');
 
 // set config
 faux.config.set('auth.namespace', '/auth');
+faux.config.set('api.prefix', '/api');
 
 // Generate API (e.g. /users)
 faux.register(UserModel);


### PR DESCRIPTION
# Description

Currently, the app registers all routes without prefixes, yielding in endpoints such as `localhost:3000/users`. For further customization, a configuration option should be added which sets a prefix to all endpoints.

## Solution

Defined `api.prefix` to the configurations.

## Proposed API

```js
const faux = require('faux-call');

faux.config.set('api.prefix', '/api'); // e.g. localhost:3000/api/users
```

## Issue

Resolves #6 

## Release

- **Version 0.2.0** https://github.com/olavoasantos/faux-call/compare/master...rt/version-0.2.0