### PR TITLE
[FEATURE] Add relationship routes

### DIFF
--- a/responses/hasOneDeleteResponse.js
+++ b/responses/hasOneDeleteResponse.js
@@ -2,6 +2,7 @@ const { getDataFromBody } = require('../helpers');
 
 /**
  *  hasOneDeleteResponse
+ *
  */
 const hasOneDeleteResponse = (Model, Relationship) => (req, res) => {
   const row = Relationship.database.where('id', parseInt(req.params.relationshipId));


### PR DESCRIPTION
# Description

Currently, Faux allows us to access the model's relationship data by eager loading it. But, when generating attribute routes, there is no route to access the relationships. These routes would help the users access, create and modify the relationships in a clearer way.

## Proposed API

Define the relationship route flag on the model:

```js
Model = {
  // ...
  route: '/base/route',
  relationshipRoutes: true,
  hasOne: [
    'HasOneRelationship',
  ],
  hasMany: [
    'HasManyRelationship',
  ],
  // ...
};
```

This generates four routes for each relationship:

- **GET - `/base/route/:id/relationship`**: Lists all related rows
- **POST - `/base/route/:id/relationship`**: Adds a new row to the model
- **PATCH - `/base/route/:id/relationship/:relationship_id`**: Updates a related model
- **DELETE - `/base/route/:id/relationship/:relationship_id`**: Deletes a related model

## Example

### Model

```js
UserSchema = {
  // ...
  route: '/users',
  relationshipRoutes: true,
  hasOne: [
    'Profile',
  ],
  // ...
};
```

### Generated routes

- **GET - `/users/1/profile`**: Lists all related rows
- **POST - `/users/1/profile`**: Adds a new row to the model
- **PATCH - `/users/1/profile/1`**: Updates a related model
- **DELETE - `/users/1/profile/1`**: Deletes a related model


## Issue

Resolves #8 

## Release

- **Version 0.2.0** https://github.com/olavoasantos/faux-call/compare/master...rt/version-0.2.0